### PR TITLE
Backslashes are bad for OS independence mmkay

### DIFF
--- a/src/main/java/lilylicious/staticchunkmanager/chunk/Chunks.java
+++ b/src/main/java/lilylicious/staticchunkmanager/chunk/Chunks.java
@@ -31,8 +31,8 @@ public class Chunks {
 
         IntegratedServer intServ = Minecraft.getMinecraft().getIntegratedServer();
 
-        File worldFolder = new File("saves\\" + intServ.getFolderName());
-        RegionFile region = new RegionFile(new File(worldFolder, "\\region\\r." + regionX + "." + regionZ + ".mca"));
+        File worldFolder = new File("saves/" + intServ.getFolderName());
+        RegionFile region = new RegionFile(new File(worldFolder, "/region/r." + regionX + "." + regionZ + ".mca"));
 
         try {
             // chunkX - regionX*32

--- a/src/main/java/lilylicious/staticchunkmanager/commands/ChunkSaveCommand.java
+++ b/src/main/java/lilylicious/staticchunkmanager/commands/ChunkSaveCommand.java
@@ -70,8 +70,8 @@ public class ChunkSaveCommand implements ICommand {
         int chunkZ = MathUtils.floorDiv(blockZ, 16);
         int regionX = MathUtils.floorDiv(chunkX, 32);
         int regionZ = MathUtils.floorDiv(chunkZ, 32);
-        File worldFolder = new File("saves\\" + intServ.getFolderName());
-        RegionFile region = new RegionFile(new File(worldFolder, "\\region\\r." + regionX + "." + regionZ + ".mca"));
+        File worldFolder = new File("saves/" + intServ.getFolderName());
+        RegionFile region = new RegionFile(new File(worldFolder, "/region/r." + regionX + "." + regionZ + ".mca"));
 
 
         String name = astring.length == 0 ? chunkX + "." + chunkZ : astring[0];


### PR DESCRIPTION
Apparently Java has wonky handling when it comes to backslashes, plus with forward you dont have to escape.
